### PR TITLE
Added backdoor to reflex to support neoast in-file lexer configuration

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,15 @@
 add_executable(reflex-exec
         reflex.cpp
-        reflex.h)
+        reflex.h
+        main.cpp)
 
 target_link_libraries(reflex-exec
         reflex reflex-unicode)
 
 add_executable(reflex-exec-initial
         reflex.cpp
+        reflex.h
+        main.cpp
         reflex.h
         ../unicode/initial/language_scripts.cpp
         ../unicode/initial/letter_scripts.cpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,48 @@
+/******************************************************************************\
+* Copyright (c) 2016, Robert van Engelen, Genivia Inc. All rights reserved.    *
+*                                                                              *
+* Redistribution and use in source and binary forms, with or without           *
+* modification, are permitted provided that the following conditions are met:  *
+*                                                                              *
+*   (1) Redistributions of source code must retain the above copyright notice, *
+*       this list of conditions and the following disclaimer.                  *
+*                                                                              *
+*   (2) Redistributions in binary form must reproduce the above copyright      *
+*       notice, this list of conditions and the following disclaimer in the    *
+*       documentation and/or other materials provided with the distribution.   *
+*                                                                              *
+*   (3) The name of the author may not be used to endorse or promote products  *
+*       derived from this software without specific prior written permission.  *
+*                                                                              *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED *
+* WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF         *
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO   *
+* EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,       *
+* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, *
+* PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;  *
+* OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,     *
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR      *
+* OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF       *
+* ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                                   *
+\******************************************************************************/
+
+/**
+    @file      main.cpp
+    @brief     Link main into another file
+    @author    Andrei Tumbar - andreitumbar@gmail.com
+*/
+
+#include "reflex.h"
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Main                                                                      //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+/// Main program instantiates Reflex class and runs `Reflex::main(argc, argv)`
+int main(int argc, char **argv)
+{
+    Reflex().main(argc, argv);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Adds support for the following options

```
   --input-filename=FILENAME
   --input-offset=LINE_OFFSET
```

This is used so that neoast can manually invoke reflex to support embedded lexer specification.